### PR TITLE
Adding headers to avoid ChallengeResponse

### DIFF
--- a/funmap/__init__.py
+++ b/funmap/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Zhiao Shi"""
 __email__ = 'zhiao.shi@gmail.com'
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/funmap/funmap.py
+++ b/funmap/funmap.py
@@ -4,6 +4,8 @@ import math
 import h5py
 import gzip
 import pickle
+import urllib
+import urllib.request
 import pyarrow as pa
 import pyarrow.parquet as pq
 from concurrent.futures import ThreadPoolExecutor
@@ -294,7 +296,9 @@ def get_ppi_feature():
     ppi_features = {}
     # use pandas to read the file
     for (i, url) in enumerate(urls):
-        data = pd.read_csv(url, sep='\t', header=None)
+        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0 (compatible; funmap/1.0)'})
+        response = urllib.request.urlopen(req)
+        data = pd.read_csv(response, sep='\t', header=None)
         data = data.apply(lambda x: tuple(sorted(x)), axis=1)
         ppi_name = f'{feature_names[i]}_PPI'
         ppi_features[ppi_name] = data.tolist()

--- a/funmap/utils.py
+++ b/funmap/utils.py
@@ -24,7 +24,8 @@ def is_url_scheme(path):
 
 def read_csv_with_md5_check(url, expected_md5=None, local_path='downloaded_file.csv', **kwargs):
     try:
-        response = urllib.request.urlopen(url)
+        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0 (compatible; funmap/1.0)'})
+        response = urllib.request.urlopen(req)
         content = response.read()
 
         if expected_md5:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/bzhanglab/funmap',
-    version='0.2.1',
+    version='0.2.2',
     zip_safe=False,
 )


### PR DESCRIPTION
Apperently figshare added AWS challenge. By trying to download files such as golden standard or PPI features server returning a 202 (Accepted) with x-amzn-waf-action: challenge.

Status Code: 202
Headers:
  Server: awselb/2.0
  Date: Tue, 13 Jan 2026 18:10:26 GMT
  Content-Length: 0
  Connection: close
  x-amzn-waf-action: challenge
  Cache-Control: no-store, max-age=0
  Content-Type: text/html; charset=UTF-8
  Access-Control-Allow-Origin: *
  Access-Control-Max-Age: 86400
  Access-Control-Allow-Methods: OPTIONS,GET,POST
  Access-Control-Expose-Headers: x-amzn-waf-action

Content size: 0 bytes

Adding headers should (allegedly) prevent this behaviour. At the moment neither the qc (with filter_noncoding_genes: True in config) or run command is unfunctional
